### PR TITLE
Sync main + harden client hydration/loading resilience

### DIFF
--- a/src/components/ArtisansSection.tsx
+++ b/src/components/ArtisansSection.tsx
@@ -11,7 +11,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { supabasePublic } from '@/integrations/supabase/client';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { useSafetyTimeout } from '@/hooks/useSafetyTimeout';
@@ -39,6 +39,20 @@ const ArtisansSection = ({ enabled = true }: ArtisansSectionProps) => {
   const currentLocale = i18n.language?.split('-')[0] || 'fr';
   const queryClient = useQueryClient();
   const [isRetrying, setIsRetrying] = useState(false);
+  const handleRetry = useCallback(async () => {
+    setIsRetrying(true);
+    try {
+      await queryClient.cancelQueries({
+        queryKey: ['artisans', currentLocale],
+      });
+      await queryClient.resetQueries({
+        queryKey: ['artisans', currentLocale],
+      });
+      await refetch();
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [currentLocale, queryClient, refetch]);
 
   // Fetch artisans — deferred when `enabled` is false (Phase 2 loading)
   const {
@@ -51,7 +65,7 @@ const ArtisansSection = ({ enabled = true }: ArtisansSectionProps) => {
     enabled,
     queryFn: async () => {
       console.info('[ArtisansSection] queryFn CALLED, locale:', currentLocale);
-      const { data, error } = await supabase
+      const { data, error } = await supabasePublic
         .from('artisans')
         .select(
           `
@@ -140,17 +154,7 @@ const ArtisansSection = ({ enabled = true }: ArtisansSectionProps) => {
           </p>
           <Button
             variant="outline"
-            onClick={async () => {
-              setIsRetrying(true);
-              try {
-                // resetQueries forces isLoading back to true → shows skeleton → refetches
-                await queryClient.resetQueries({ queryKey: ['artisans'] });
-              } catch {
-                /* handled by RQ */
-              } finally {
-                setTimeout(() => setIsRetrying(false), 500);
-              }
-            }}
+            onClick={handleRetry}
             disabled={isRetrying}
             className="gap-2"
           >

--- a/src/components/ArtisansSection.tsx
+++ b/src/components/ArtisansSection.tsx
@@ -39,20 +39,6 @@ const ArtisansSection = ({ enabled = true }: ArtisansSectionProps) => {
   const currentLocale = i18n.language?.split('-')[0] || 'fr';
   const queryClient = useQueryClient();
   const [isRetrying, setIsRetrying] = useState(false);
-  const handleRetry = useCallback(async () => {
-    setIsRetrying(true);
-    try {
-      await queryClient.cancelQueries({
-        queryKey: ['artisans', currentLocale],
-      });
-      await queryClient.resetQueries({
-        queryKey: ['artisans', currentLocale],
-      });
-      await refetch();
-    } finally {
-      setIsRetrying(false);
-    }
-  }, [currentLocale, queryClient, refetch]);
 
   // Fetch artisans — deferred when `enabled` is false (Phase 2 loading)
   const {
@@ -112,6 +98,21 @@ const ArtisansSection = ({ enabled = true }: ArtisansSectionProps) => {
     retryDelay: 2000,
     networkMode: 'always',
   });
+
+  const handleRetry = useCallback(async () => {
+    setIsRetrying(true);
+    try {
+      await queryClient.cancelQueries({
+        queryKey: ['artisans', currentLocale],
+      });
+      await queryClient.resetQueries({
+        queryKey: ['artisans', currentLocale],
+      });
+      await refetch();
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [currentLocale, queryClient, refetch]);
 
   // Safety timeout — escape skeleton after 12s
   const { hasTimedOut: forceRender } = useSafetyTimeout(isLoading, {

--- a/src/components/ArtisansSection.tsx
+++ b/src/components/ArtisansSection.tsx
@@ -94,8 +94,9 @@ const ArtisansSection = ({ enabled = true }: ArtisansSectionProps) => {
       }) as Artisan[];
     },
     staleTime: 5 * 60 * 1000,
-    retry: 1,
-    retryDelay: 2000,
+    // Match blog/products resilience to avoid single-shot failures in preview.
+    retry: 2,
+    retryDelay: (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 8000),
     networkMode: 'always',
   });
 

--- a/src/components/HeroImage.tsx
+++ b/src/components/HeroImage.tsx
@@ -7,6 +7,21 @@ const HeroImage = () => {
   const { t } = useTranslation('pages');
   const { heroImageData, isLoading } = useHeroImage();
 
+  const isReadableText = (value: unknown): value is string =>
+    typeof value === 'string' &&
+    value.trim().length > 0 &&
+    !value.toLowerCase().includes('undefined');
+
+  const safeAlt = isReadableText(heroImageData.altText)
+    ? heroImageData.altText
+    : t('home.heroImage.alt');
+  const safeTitle = isReadableText(heroImageData.title)
+    ? heroImageData.title
+    : t('home.heroImage.title');
+  const safeSubtitle = isReadableText(heroImageData.subtitle)
+    ? heroImageData.subtitle
+    : t('home.heroImage.subtitle');
+
   // Render default image immediately while loading data
   if (isLoading) {
     return (
@@ -54,7 +69,7 @@ const HeroImage = () => {
         {/* Main hero image with advanced loading and fallback */}
         <HeroImageComponent
           src={heroImageData.imageUrl}
-          alt={heroImageData.altText}
+          alt={safeAlt}
           className="object-cover w-full h-full rounded-lg"
           fallbackText={t('home.heroImage.fallback')}
           preload={true}
@@ -69,7 +84,7 @@ const HeroImage = () => {
       {/* Hover hint text */}
       <div className="absolute top-6 left-6 right-6 opacity-0 group-hover:opacity-100 transition-opacity duration-700 ease-in-out">
         <div className="bg-foreground/60 text-background px-4 py-2 rounded-lg backdrop-blur-sm">
-          <p className="text-sm font-medium">{heroImageData.altText}</p>
+          <p className="text-sm font-medium">{safeAlt}</p>
         </div>
       </div>
 
@@ -77,10 +92,10 @@ const HeroImage = () => {
       <div className="absolute bottom-6 left-6 right-6 group-hover:opacity-0 transition-opacity duration-700 ease-in-out">
         <div className="bg-card/95 backdrop-blur-sm px-6 py-4 rounded-lg shadow-lg border border-border/50">
           <p className="text-sm font-medium text-foreground mb-1">
-            {heroImageData.title}
+            {safeTitle}
           </p>
           <p className="text-xs text-muted-foreground">
-            {heroImageData.subtitle}
+            {safeSubtitle}
           </p>
         </div>
       </div>

--- a/src/components/ProductShowcase.tsx
+++ b/src/components/ProductShowcase.tsx
@@ -41,17 +41,16 @@ const ProductShowcase = () => {
   const handleRetry = useCallback(async () => {
     setIsRetrying(true);
     try {
+      await queryClient.cancelQueries({ queryKey: ['products'] });
       // resetQueries (not invalidate) forces isLoading back to true
       await queryClient.resetQueries({ queryKey: ['products'] });
-      await queryClient.resetQueries({
-        queryKey: ['products-with-translations'],
-      });
+      await refetch();
     } catch {
       // Error handled by React Query
     } finally {
-      setTimeout(() => setIsRetrying(false), 500);
+      setIsRetrying(false);
     }
-  }, [queryClient]);
+  }, [queryClient, refetch]);
 
   // Safety timeout — force out of skeleton after 12s
   const { hasTimedOut: forceRender } = useSafetyTimeout(loading, {

--- a/src/hooks/useHeroImage.ts
+++ b/src/hooks/useHeroImage.ts
@@ -21,8 +21,14 @@ function getInitialHeroImage(): HeroImageData {
     const cached = localStorage.getItem(HERO_CACHE_KEY);
     if (cached) {
       const parsed = JSON.parse(cached) as HeroImageData;
-      // Basic validation
-      if (parsed.imageUrl && parsed.title) {
+      // Basic validation + guard against stale "undefined" text cached from old data.
+      const hasValidText =
+        typeof parsed.title === 'string' &&
+        typeof parsed.subtitle === 'string' &&
+        !parsed.title.toLowerCase().includes('undefined') &&
+        !parsed.subtitle.toLowerCase().includes('undefined');
+
+      if (parsed.imageUrl && parsed.title && hasValidText) {
         return parsed;
       }
     }

--- a/src/hooks/useTranslatedContent.ts
+++ b/src/hooks/useTranslatedContent.ts
@@ -124,8 +124,9 @@ export function useBlogPostsWithTranslations() {
     staleTime: 2 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
-    retry: 1,
-    retryDelay: 2000,
+    retry: 2,
+    retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 8000),
+    networkMode: 'always',
   });
 
   return query;

--- a/src/hooks/useTranslatedContent.ts
+++ b/src/hooks/useTranslatedContent.ts
@@ -20,6 +20,11 @@ import {
   DEFAULT_LOCALE,
 } from '@/services/translationService';
 
+// Keep content-query resilience consistent across Home/Shop/Blog surfaces.
+const CONTENT_QUERY_RETRY_COUNT = 2;
+const CONTENT_QUERY_RETRY_DELAY_MS = (attempt: number) =>
+  Math.min(1000 * Math.pow(2, attempt), 8000);
+
 /**
  * Get current locale from i18n
  */
@@ -64,8 +69,8 @@ export function useProductsWithTranslations() {
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
-    retry: 2,
-    retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 8000),
+    retry: CONTENT_QUERY_RETRY_COUNT,
+    retryDelay: CONTENT_QUERY_RETRY_DELAY_MS,
     networkMode: 'always',
   });
 
@@ -124,8 +129,8 @@ export function useBlogPostsWithTranslations() {
     staleTime: 2 * 60 * 1000,
     refetchOnWindowFocus: false,
     refetchOnMount: true,
-    retry: 2,
-    retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 8000),
+    retry: CONTENT_QUERY_RETRY_COUNT,
+    retryDelay: CONTENT_QUERY_RETRY_DELAY_MS,
     networkMode: 'always',
   });
 

--- a/src/integrations/supabase/client.state-poisoning.test.ts
+++ b/src/integrations/supabase/client.state-poisoning.test.ts
@@ -25,7 +25,12 @@ async function loadWrappedFetch(): Promise<WrappedFetch> {
   });
 
   await import('./client');
-  const clientCall = createClientMock.mock.calls.at(-1);
+  // The module creates both an auth-aware client and a public client.
+  // These assertions validate auth poisoning cleanup, so pick the client
+  // that persists sessions (the auth-aware one).
+  const clientCall = createClientMock.mock.calls.find(
+    (call) => call[2]?.auth?.persistSession === true
+  );
   const options = clientCall?.[2] as {
     global: { fetch: WrappedFetch };
   };

--- a/src/integrations/supabase/client.state-poisoning.test.ts
+++ b/src/integrations/supabase/client.state-poisoning.test.ts
@@ -55,9 +55,12 @@ describe('supabase client auth-state poisoning diagnostics', () => {
     localStorage.setItem('editor-store-state', 'keep');
 
     const wrappedFetch = await loadWrappedFetch();
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ message: 'invalid JWT' }), { status: 401 })
-    );
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'invalid JWT' }), { status: 401 })
+      )
+      // Auth-aware fetch retries once after token cleanup.
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
 
     await wrappedFetch(
       'https://xcvlijchkmhjonhfildm.supabase.co/rest/v1/products'
@@ -80,11 +83,14 @@ describe('supabase client auth-state poisoning diagnostics', () => {
     localStorage.setItem('cart-storage', '{"items":[3]}');
 
     const wrappedFetch = await loadWrappedFetch();
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ message: 'invalid JWT: bad signature' }), {
-        status: 403,
-      })
-    );
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'invalid JWT: bad signature' }), {
+          status: 403,
+        })
+      )
+      // Auth-aware fetch retries once after token cleanup.
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
 
     await wrappedFetch(
       'https://xcvlijchkmhjonhfildm.supabase.co/auth/v1/user'

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -14,6 +14,29 @@ if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
 // Guest session key constant
 const GUEST_SESSION_KEY = 'guest_session';
 
+function clearSupabaseAuthStorage() {
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (
+        key &&
+        (key.startsWith('sb-') || key.startsWith('supabase.auth.'))
+      ) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key) => localStorage.removeItem(key));
+    if (keysToRemove.length > 0) {
+      console.warn(
+        `[SupabaseFetch] Cleared ${keysToRemove.length} stale auth key(s)`
+      );
+    }
+  } catch {
+    // localStorage may be unavailable (private mode), ignore
+  }
+}
+
 /**
  * Get the current guest ID from storage (if exists)
  * This is called DYNAMICALLY on each request via the fetch wrapper,
@@ -43,6 +66,76 @@ const getGuestId = (): string => {
   return '';
 };
 
+function createDynamicFetch(options: {
+  timeoutMs: number;
+  clearAuthOn401?: boolean;
+  retryOnceAfter401?: boolean;
+}) {
+  const { timeoutMs, clearAuthOn401 = false, retryOnceAfter401 = false } =
+    options;
+
+  const doFetch = async (
+    url: RequestInfo | URL,
+    init?: RequestInit,
+    hasRetried = false
+  ): Promise<Response> => {
+    const guestId = getGuestId();
+    const headers = new Headers(init?.headers);
+    if (guestId) {
+      headers.set('x-guest-id', guestId);
+    }
+
+    const controller = new AbortController();
+    const existingSignal = init?.signal;
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    if (existingSignal) {
+      existingSignal.addEventListener('abort', () => controller.abort());
+    }
+
+    const urlStr =
+      typeof url === 'string'
+        ? url
+        : url instanceof URL
+          ? url.href
+          : '(Request)';
+    const shortUrl = urlStr.includes('supabase.co')
+      ? urlStr.split('supabase.co')[1]?.substring(0, 60)
+      : urlStr.substring(0, 80);
+
+    try {
+      console.info(`[SupabaseFetch] → ${shortUrl}`);
+      const response = await fetch(url, {
+        ...init,
+        headers,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      console.info(`[SupabaseFetch] ← ${response.status} ${shortUrl}`);
+
+      if (response.status === 401 && clearAuthOn401) {
+        console.warn('[SupabaseFetch] 401 detected — clearing stale auth tokens');
+        clearSupabaseAuthStorage();
+
+        if (retryOnceAfter401 && !hasRetried) {
+          console.warn(
+            '[SupabaseFetch] Retrying request once after auth storage cleanup'
+          );
+          return doFetch(url, init, true);
+        }
+      }
+
+      return response;
+    } catch (err) {
+      clearTimeout(timeoutId);
+      console.error(`[SupabaseFetch] ✘ ${shortUrl}`, err?.message || err);
+      throw err;
+    }
+  };
+
+  return (url: RequestInfo | URL, init?: RequestInit) => doFetch(url, init);
+}
+
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
@@ -56,89 +149,12 @@ export const supabase = createClient<Database>(
       autoRefreshToken: true,
     },
     global: {
-      // Use a function to dynamically resolve x-guest-id on EVERY request
-      // Prevents 42501 RLS errors when guest ID wasn't yet generated
-      // Also adds AbortController timeout to prevent hanging connections
-      // that exhaust the browser's 6-connection-per-host limit.
-      fetch: (url: RequestInfo | URL, options?: RequestInit) => {
-        const guestId = getGuestId();
-        const headers = new Headers(options?.headers);
-        if (guestId) {
-          headers.set('x-guest-id', guestId);
-        }
-
-        // Abort hanging requests after 15s to free connection slots.
-        // Previous value was 30s, but that's longer than the UI safety
-        // timeout (12s), meaning users see errors before the fetch fails.
-        // 15s gives enough headroom for browser connection queuing while
-        // still failing fast enough for React Query retries to complete.
-        const controller = new AbortController();
-        const existingSignal = options?.signal;
-        const timeoutId = setTimeout(() => controller.abort(), 15_000);
-
-        // If caller already provided a signal, respect it too
-        if (existingSignal) {
-          existingSignal.addEventListener('abort', () => controller.abort());
-        }
-
-        const urlStr =
-          typeof url === 'string'
-            ? url
-            : url instanceof URL
-              ? url.href
-              : '(Request)';
-        const shortUrl = urlStr.includes('supabase.co')
-          ? urlStr.split('supabase.co')[1]?.substring(0, 60)
-          : urlStr.substring(0, 80);
-        console.info(`[SupabaseFetch] → ${shortUrl}`);
-
-        return fetch(url, {
-          ...options,
-          headers,
-          signal: controller.signal,
-        })
-          .then((response) => {
-            clearTimeout(timeoutId);
-            console.info(`[SupabaseFetch] ← ${response.status} ${shortUrl}`);
-
-            // CRITICAL FIX: If we get a 401 (bad JWT), the stored auth token
-            // is poisoning ALL requests — even anonymous ones.
-            // Clear the bad token immediately so subsequent retries use the anon key.
-            if (response.status === 401) {
-              console.warn(
-                '[SupabaseFetch] 401 detected — clearing stale auth tokens'
-              );
-              try {
-                // Remove all Supabase auth keys from storage
-                const keysToRemove: string[] = [];
-                for (let i = 0; i < localStorage.length; i++) {
-                  const key = localStorage.key(i);
-                  if (
-                    key &&
-                    (key.startsWith('sb-') || key.startsWith('supabase.auth.'))
-                  ) {
-                    keysToRemove.push(key);
-                  }
-                }
-                keysToRemove.forEach((key) => localStorage.removeItem(key));
-                if (keysToRemove.length > 0) {
-                  console.warn(
-                    `[SupabaseFetch] Cleared ${keysToRemove.length} stale auth keys`
-                  );
-                }
-              } catch (e) {
-                // Storage access may fail in private mode — ignore
-              }
-            }
-
-            return response;
-          })
-          .catch((err) => {
-            clearTimeout(timeoutId);
-            console.error(`[SupabaseFetch] ✘ ${shortUrl}`, err?.message || err);
-            throw err;
-          });
-      },
+      // Auth-aware client: handles stale JWT poisoning and retries once after cleanup.
+      fetch: createDynamicFetch({
+        timeoutMs: 15_000,
+        clearAuthOn401: true,
+        retryOnceAfter401: true,
+      }),
     },
     realtime: {
       params: {
@@ -150,5 +166,24 @@ export const supabase = createClient<Database>(
   }
 );
 
-// NOTE: createGuestClient was REMOVED to prevent "Multiple GoTrueClient instances" warnings.
-// The main `supabase` client already resolves x-guest-id dynamically on every request
+// Public client for anonymous/public read flows.
+// Intentionally does not persist auth session so stale JWT cannot poison
+// products/blog/artisans requests in embedded preview environments.
+export const supabasePublic = createClient<Database>(
+  SUPABASE_URL,
+  SUPABASE_PUBLISHABLE_KEY,
+  {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+    global: {
+      fetch: createDynamicFetch({
+        timeoutMs: 10_000,
+        clearAuthOn401: false,
+        retryOnceAfter401: false,
+      }),
+    },
+  }
+);

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -79,10 +79,14 @@ const getGuestId = (): string => {
 
 function createDynamicFetch(options: {
   timeoutMs: number;
-  clearAuthOn401?: boolean;
-  retryOnceAfter401?: boolean;
+  clearAuthOnAuthError?: boolean;
+  retryOnceAfterAuthError?: boolean;
 }) {
-  const { timeoutMs, clearAuthOn401 = false, retryOnceAfter401 = false } =
+  const {
+    timeoutMs,
+    clearAuthOnAuthError = false,
+    retryOnceAfterAuthError = false,
+  } =
     options;
 
   const doFetch = async (
@@ -124,13 +128,18 @@ function createDynamicFetch(options: {
       clearTimeout(timeoutId);
       console.info(`[SupabaseFetch] ← ${response.status} ${shortUrl}`);
 
-      if ((response.status === 401 || response.status === 403) && clearAuthOn401) {
+      if (
+        (response.status === 401 || response.status === 403) &&
+        clearAuthOnAuthError
+      ) {
         console.warn(
           `[SupabaseFetch] ${response.status} detected — clearing stale auth tokens`
         );
         clearSupabaseAuthStorage();
 
-        if (retryOnceAfter401 && !hasRetried) {
+        // Retry once after cleanup to avoid forcing the user into a manual reload.
+        // hasRetried guards against loops when the server keeps rejecting.
+        if (retryOnceAfterAuthError && !hasRetried) {
           console.warn(
             '[SupabaseFetch] Retrying request once after auth storage cleanup'
           );
@@ -165,8 +174,8 @@ export const supabase = createClient<Database>(
       // Auth-aware client: handles stale JWT poisoning and retries once after cleanup.
       fetch: createDynamicFetch({
         timeoutMs: 15_000,
-        clearAuthOn401: true,
-        retryOnceAfter401: true,
+        clearAuthOnAuthError: true,
+        retryOnceAfterAuthError: true,
       }),
     },
     realtime: {
@@ -194,8 +203,8 @@ export const supabasePublic = createClient<Database>(
     global: {
       fetch: createDynamicFetch({
         timeoutMs: 10_000,
-        clearAuthOn401: false,
-        retryOnceAfter401: false,
+        clearAuthOnAuthError: false,
+        retryOnceAfterAuthError: false,
       }),
     },
   }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -63,6 +63,8 @@ const Blog = () => {
   // Dynamic tag translation
   const { translateTag } = useTranslateTag();
 
+  const getSafeTagLabel = (tag: string) => translateTag(tag, currentLang) || tag;
+
   // Get date-fns locale based on current language
   const dateLocale = i18n.language?.startsWith('fr') ? fr : enUS;
 
@@ -236,7 +238,7 @@ const Blog = () => {
 
                     {post.tags && post.tags[0] && (
                       <Badge className="mb-2 bg-primary/10 text-primary hover:bg-primary/20 border-none">
-                        {translateTag(post.tags[0], currentLang)}
+                        {getSafeTagLabel(post.tags[0])}
                       </Badge>
                     )}
 
@@ -295,7 +297,7 @@ const Blog = () => {
 
                   {post.tags && post.tags[0] && (
                     <Badge className="mb-2 bg-primary/10 text-primary hover:bg-primary/20 border-none text-xs">
-                      {translateTag(post.tags[0], currentLang)}
+                      {getSafeTagLabel(post.tags[0])}
                     </Badge>
                   )}
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,7 +1,8 @@
-import { CalendarIcon, User, AlertCircle, RefreshCw } from 'lucide-react';
+import { CalendarIcon, User, AlertCircle, RefreshCw, Loader2 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import SEOHelmet from '@/components/seo/SEOHelmet';
 import { format } from 'date-fns';
 import { fr, enUS } from 'date-fns/locale';
@@ -27,6 +28,24 @@ const Blog = () => {
     error: fetchError,
     refetch,
   } = useBlogPostsWithTranslations();
+  const queryClient = useQueryClient();
+  const [isRetrying, setIsRetrying] = useState(false);
+  const currentLang = i18n.language?.split('-')[0] || 'fr';
+
+  const handleRetry = useCallback(async () => {
+    setIsRetrying(true);
+    try {
+      await queryClient.cancelQueries({
+        queryKey: ['blogPosts', currentLang],
+      });
+      await queryClient.resetQueries({
+        queryKey: ['blogPosts', currentLang],
+      });
+      await refetch();
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [currentLang, queryClient, refetch]);
 
   // Safety timeout — force render after 8s
   const { hasTimedOut: forceRender, isSlowLoading } = useSafetyTimeout(
@@ -38,12 +57,11 @@ const Blog = () => {
   );
 
   // NOTE: Auto-refetch on timeout was REMOVED — it caused a refetch loop
-  // that cancelled in-flight queries. React Query's own retry (1 attempt)
-  // handles transient failures. The safety timeout now just shows error UI.
+  // that cancelled in-flight queries. React Query retries transient failures;
+  // the safety timeout now just shows error UI.
 
   // Dynamic tag translation
   const { translateTag } = useTranslateTag();
-  const currentLang = i18n.language?.split('-')[0] || 'fr';
 
   // Get date-fns locale based on current language
   const dateLocale = i18n.language?.startsWith('fr') ? fr : enUS;
@@ -111,9 +129,15 @@ const Blog = () => {
                     'Le chargement a pris trop de temps. Veuillez réessayer.'
                   )}
             </p>
-            <Button onClick={() => refetch()} className="gap-2">
-              <RefreshCw className="h-4 w-4" />
-              {t('blog.retry', 'Réessayer')}
+            <Button onClick={handleRetry} disabled={isRetrying} className="gap-2">
+              {isRetrying ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+              {isRetrying
+                ? t('common:messages.loading', 'Chargement…')
+                : t('blog.retry', 'Réessayer')}
             </Button>
           </div>
         </div>

--- a/src/services/heroImageService.ts
+++ b/src/services/heroImageService.ts
@@ -17,6 +17,28 @@ const defaultHeroImage: HeroImageData = {
   subtitle: 'Chapeau tressé et sac naturel - Fait main avec amour',
 };
 
+const isUsableText = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.trim().length > 0 &&
+  !value.toLowerCase().includes('undefined');
+
+function normalizeHeroImageData(data: Partial<HeroImageData> | null): HeroImageData {
+  return {
+    id: data?.id,
+    imageUrl: isUsableText(data?.imageUrl)
+      ? data.imageUrl
+      : defaultHeroImage.imageUrl,
+    altText: isUsableText(data?.altText)
+      ? data.altText
+      : defaultHeroImage.altText,
+    title: isUsableText(data?.title) ? data.title : defaultHeroImage.title,
+    subtitle: isUsableText(data?.subtitle)
+      ? data.subtitle
+      : defaultHeroImage.subtitle,
+    isActive: data?.isActive ?? true,
+  };
+}
+
 export const heroImageService = {
   // Get active hero image from database
   get: async (): Promise<HeroImageData> => {
@@ -37,14 +59,14 @@ export const heroImageService = {
         return defaultHeroImage;
       }
 
-      return {
+      return normalizeHeroImageData({
         id: data.id,
         imageUrl: data.image_url,
         altText: data.alt_text,
         title: data.title,
         subtitle: data.subtitle,
         isActive: data.is_active,
-      };
+      });
     } catch (error) {
       console.error('Error getting hero image data:', error);
       return defaultHeroImage;
@@ -108,14 +130,14 @@ export const heroImageService = {
         throw error;
       }
 
-      return {
+      return normalizeHeroImageData({
         id: newData.id,
         imageUrl: newData.image_url,
         altText: newData.alt_text,
         title: newData.title,
         subtitle: newData.subtitle,
         isActive: newData.is_active,
-      };
+      });
     } catch (error) {
       console.error('Error saving hero image data:', error);
       throw new Error('Erreur lors de la sauvegarde');
@@ -145,14 +167,14 @@ export const heroImageService = {
         throw error;
       }
 
-      return {
+      return normalizeHeroImageData({
         id: updatedData.id,
         imageUrl: updatedData.image_url,
         altText: updatedData.alt_text,
         title: updatedData.title,
         subtitle: updatedData.subtitle,
         isActive: updatedData.is_active,
-      };
+      });
     } catch (error) {
       console.error('Error updating hero image data:', error);
       throw new Error('Erreur lors de la mise à jour');

--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -16,6 +16,13 @@
 import { supabasePublic } from '@/integrations/supabase/client';
 import i18n from '@/i18n';
 
+const isDebugLoggingEnabled = import.meta.env.DEV;
+const logDebug = (...args: unknown[]) => {
+  if (isDebugLoggingEnabled) {
+    console.info(...args);
+  }
+};
+
 // Supported locales
 export type SupportedLocale = 'fr' | 'en' | 'ar' | 'es' | 'de';
 export const DEFAULT_LOCALE: SupportedLocale = 'fr';
@@ -44,7 +51,7 @@ async function safeQuery<T>(
   label: string
 ): Promise<{ data: T | null; error: unknown }> {
   const start = performance.now();
-  console.info(`[safeQuery] ⏳ ${label} — starting…`);
+  logDebug(`[safeQuery] ⏳ ${label} — starting…`);
   try {
     // Hard timeout at service layer so UI never waits indefinitely.
     const timeoutMs = 8000;
@@ -79,7 +86,7 @@ async function safeQuery<T>(
         result.error
       );
     } else {
-      console.info(`[safeQuery] ✅ ${label} → ${size} rows in ${elapsed}ms`);
+      logDebug(`[safeQuery] ✅ ${label} → ${size} rows in ${elapsed}ms`);
     }
     return result;
   } catch (err) {
@@ -263,7 +270,7 @@ export async function getProductWithTranslation(
     return null;
   }
 
-  console.info(
+  logDebug(
     `[TranslationService] getProductWithTranslation(${productId}) → ${Math.round(performance.now() - startMs)}ms`
   );
 
@@ -285,7 +292,7 @@ export async function getProductWithTranslation(
 export async function getProductsWithTranslations(
   locale: SupportedLocale = getCurrentLocale()
 ): Promise<ProductWithTranslation[]> {
-  console.info(
+  logDebug(
     '[TranslationService] getProductsWithTranslations CALLED, locale:',
     locale
   );
@@ -327,7 +334,7 @@ export async function getProductsWithTranslations(
   }
 
   const elapsed = Math.round(performance.now() - startMs);
-  console.info(
+  logDebug(
     `[TranslationService] getProductsWithTranslations(${locale}) → ${(products as unknown[]).length} products in ${elapsed}ms (1 query, joined)`
   );
 
@@ -534,12 +541,12 @@ export async function getBlogPostsWithTranslations(
   }
 
   if ((posts as unknown[]).length === 0) {
-    console.info('[TranslationService] No published blog posts found');
+    logDebug('[TranslationService] No published blog posts found');
     return [];
   }
 
   const elapsed = Math.round(performance.now() - startMs);
-  console.info(
+  logDebug(
     `[TranslationService] getBlogPostsWithTranslations(${locale}) → ${(posts as unknown[]).length} posts in ${elapsed}ms (1 query, joined)`
   );
 

--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -13,7 +13,7 @@
  * This service catches AbortError and other failures, returning { data: null, error }.
  */
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabasePublic } from '@/integrations/supabase/client';
 import i18n from '@/i18n';
 
 // Supported locales
@@ -46,7 +46,26 @@ async function safeQuery<T>(
   const start = performance.now();
   console.info(`[safeQuery] ⏳ ${label} — starting…`);
   try {
-    const result = await promise;
+    // Hard timeout at service layer so UI never waits indefinitely.
+    const timeoutMs = 8000;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const timeoutResult = new Promise<{ data: T | null; error: unknown }>(
+      (resolve) => {
+        timeoutId = setTimeout(
+          () =>
+            resolve({
+              data: null,
+              error: new Error(
+                `[safeQuery] ${label} timed out after ${timeoutMs}ms`
+              ),
+            }),
+          timeoutMs
+        );
+      }
+    );
+
+    const result = await Promise.race([Promise.resolve(promise), timeoutResult]);
+    if (timeoutId) clearTimeout(timeoutId);
     const elapsed = Math.round(performance.now() - start);
     const size = Array.isArray(result.data)
       ? result.data.length
@@ -200,7 +219,7 @@ export async function getProductWithTranslation(
 
   // First, try to get translation for requested locale
   const { data: translation } = await safeQuery(
-    supabase
+    supabasePublic
       .from('product_translations')
       .select('*')
       .eq('product_id', productId)
@@ -215,7 +234,7 @@ export async function getProductWithTranslation(
 
   if (!translation && locale !== DEFAULT_LOCALE) {
     const { data: fallback } = await safeQuery(
-      supabase
+      supabasePublic
         .from('product_translations')
         .select('*')
         .eq('product_id', productId)
@@ -235,7 +254,7 @@ export async function getProductWithTranslation(
 
   // Get base product data
   const { data: product, error: productError } = await safeQuery(
-    supabase.from('products').select('*').eq('id', productId).single(),
+    supabasePublic.from('products').select('*').eq('id', productId).single(),
     `product(${productId})`
   );
 
@@ -274,7 +293,7 @@ export async function getProductsWithTranslations(
 
   // Single query with embedded translations via Supabase join
   const { data: products, error: productsError } = await safeQuery(
-    supabase
+    supabasePublic
       .from('products')
       .select(
         `
@@ -423,7 +442,7 @@ export async function getBlogPostWithTranslation(
   locale: SupportedLocale = getCurrentLocale()
 ): Promise<BlogPostWithTranslation | null> {
   const { data: translation } = await safeQuery(
-    supabase
+    supabasePublic
       .from('blog_post_translations')
       .select('*')
       .eq('blog_post_id', blogPostId)
@@ -437,7 +456,7 @@ export async function getBlogPostWithTranslation(
 
   if (!translation && locale !== DEFAULT_LOCALE) {
     const { data: fallback } = await safeQuery(
-      supabase
+      supabasePublic
         .from('blog_post_translations')
         .select('*')
         .eq('blog_post_id', blogPostId)
@@ -456,7 +475,7 @@ export async function getBlogPostWithTranslation(
   > | null;
 
   const { data: post, error: postError } = await safeQuery(
-    supabase.from('blog_posts').select('*').eq('id', blogPostId).single(),
+    supabasePublic.from('blog_posts').select('*').eq('id', blogPostId).single(),
     `blog_post(${blogPostId})`
   );
 
@@ -484,7 +503,7 @@ export async function getBlogPostsWithTranslations(
   const startMs = performance.now();
 
   const { data: posts, error: postsError } = await safeQuery(
-    supabase
+    supabasePublic
       .from('blog_posts')
       .select(
         `
@@ -552,7 +571,7 @@ export async function getBlogPostBySlugWithTranslation(
   locale: SupportedLocale = getCurrentLocale()
 ): Promise<BlogPostWithTranslation | null> {
   const { data: post, error } = await safeQuery(
-    supabase
+    supabasePublic
       .from('blog_posts')
       .select('*')
       .eq('slug', slug)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Synced this branch with latest `main` and resolved the Supabase client merge conflict while preserving auth-poisoning recovery logic.
- Optimized resilience config across products/blog/artisans: consistent retry/backoff behavior and safer auth-error fetch semantics.
- Reduced production log noise by making translation-service info logs dev-only.
- Fixed diagnostics tests for dual Supabase clients and one-shot auth-error retry behavior.
- Added defensive UI/data sanitization to prevent `undefined` metadata rendering in Home hero and Blog tag labels.

## Why
- Keep branch current with latest checkout hardening from `main`.
- Improve runtime reliability under stale auth/storage and transient failures.
- Remove user-visible metadata corruption (`undefined` labels) in critical surfaces.

## Validation
- `npm run build`
- `npm run test:unit -- src/integrations/supabase/client.state-poisoning.test.ts src/tests/ui-resilience.test.ts src/tests/partial-failure-isolation.test.ts src/hooks/useSafetyTimeout.diagnostics.test.tsx`
- Manual smoke walkthrough with hard refresh across `/`, `/products`, `/blog`, `/auth` confirming no `undefined` metadata.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0c9a8eb-1106-4b51-8c9f-848b740cfe9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0c9a8eb-1106-4b51-8c9f-848b740cfe9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

